### PR TITLE
Refactor of decode method for speedup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,7 @@ authors = [
 license = { file = "LICENSE" }
 
 requires-python = ">=3.8"
-dependencies = [
-   "ldpc"
-]
+dependencies = []
 version = "0.0.1"
 
 [tool.setuptools.packages.find]

--- a/src/BPOTF/OBPOTF.h
+++ b/src/BPOTF/OBPOTF.h
@@ -36,8 +36,6 @@ class OBPOTF
    float const m_p;  // Error probabilities.
    uint64_t m_u64_pcm_rows;   // Parity check matrix number of rows.
    uint64_t m_u64_pcm_cols;   // Parity check matrix number of columns.
-   std::vector<int64_t> m_ai64_idx_matrix; // Row indexes per column where a non-trivial element is located in the pcm.
-   uint16_t m_u16_idx_matrix_rows;  // Row number of m_ai64_idx_matrix. Columns will be m_u64_pcm_cols.
 
    OCSC * m_po_csc_mat = nullptr; // Matrix in Compressed-Sparse-Column format.
 
@@ -47,16 +45,13 @@ class OBPOTF
 
    std::vector<uint64_t> m_au64_index_array; // Array that holds indexes from 0 to m_u64_pcm_cols-1 to be sorted
 
-   std::vector<uint64_t> koh_v2_classical_uf(py::array_t<double> const & llrs);
+   private:
+   std::vector<uint64_t> koh_v2_classical_uf(std::vector<double> const & llrs);
 
-   std::vector<uint64_t> koh_v2_uf(py::array_t<float> const & llrs);
-
-   std::vector<uint64_t> koh_v2_uf_csc(py::array_t<float> const & llrs);
-   std::vector<uint64_t> koh_v2_uf_csc(std::vector<double> const & llrs);
+   std::vector<uint64_t> koh_v2_uf(std::vector<double> const & llrs);
 
    std::vector<uint64_t> sort_indexes(py::array_t<double> const & llrs);
 
-   std::vector<uint64_t *> sort_indexes_nc(py::array_t<double> const & llrs);
    std::vector<uint64_t *> sort_indexes_nc(std::vector<double> const & llrs);
 
    public:

--- a/src/BPOTF/OBPOTF.h
+++ b/src/BPOTF/OBPOTF.h
@@ -26,6 +26,8 @@
 // Custom includes
 #include "CSC/OCSC.h"
 
+#include "../ldpc_v2_src/bp.hpp"
+
 namespace py = pybind11;
 
 class OBPOTF
@@ -36,21 +38,26 @@ class OBPOTF
    uint64_t m_u64_pcm_cols;   // Parity check matrix number of columns.
    std::vector<int64_t> m_ai64_idx_matrix; // Row indexes per column where a non-trivial element is located in the pcm.
    uint16_t m_u16_idx_matrix_rows;  // Row number of m_ai64_idx_matrix. Columns will be m_u64_pcm_cols.
-   OCSC * m_po_csc_mat; // Matrix in Compressed-Sparse-Column format.
-   std::vector<uint64_t> m_au64_index_array; // Array that holds indexes from 0 to m_u64_pcm_cols-1 to be sorted
 
-   py::object m_bpd; // Python class object from ldpc for decoding
-   py::object m_bpd_secondary; // Python class object from ldpc for decoding
+   OCSC * m_po_csc_mat = nullptr; // Matrix in Compressed-Sparse-Column format.
+
+   ldpc::bp::BpSparse * m_po_bpsparse = nullptr; // Pointer to the pcm in format for BpDecoder object
+   ldpc::bp::BpDecoder * m_po_primary_bp = nullptr; // Pointer to primary BP decoder object.
+   ldpc::bp::BpDecoder * m_po_secondary_bp = nullptr; // Pointer to secondary BP decoder in case the first one fails and Kruskal is needed.
+
+   std::vector<uint64_t> m_au64_index_array; // Array that holds indexes from 0 to m_u64_pcm_cols-1 to be sorted
 
    std::vector<uint64_t> koh_v2_classical_uf(py::array_t<double> const & llrs);
 
    std::vector<uint64_t> koh_v2_uf(py::array_t<float> const & llrs);
 
    std::vector<uint64_t> koh_v2_uf_csc(py::array_t<float> const & llrs);
+   std::vector<uint64_t> koh_v2_uf_csc(std::vector<double> const & llrs);
 
    std::vector<uint64_t> sort_indexes(py::array_t<double> const & llrs);
 
    std::vector<uint64_t *> sort_indexes_nc(py::array_t<double> const & llrs);
+   std::vector<uint64_t *> sort_indexes_nc(std::vector<double> const & llrs);
 
    public:
    /********************************************************************************************************************
@@ -72,7 +79,7 @@ class OBPOTF
     *******************************************************************************************************************/
    ~OBPOTF();
 
-   py::array_t<uint8_t> decode(py::array_t<int, py::array::c_style> syndrome);
+   py::array_t<uint8_t> decode(py::array_t<uint8_t, py::array::c_style> syndrome);
 
    /********************************************************************************************************************
     * @brief Prints the object's member. Developing purposes and testing.

--- a/src/ldpc_v2_src/bp.hpp
+++ b/src/ldpc_v2_src/bp.hpp
@@ -1,0 +1,610 @@
+#ifndef BP_H
+#define BP_H
+
+#include <vector>
+#include <memory>
+#include <iterator>
+#include <cmath>
+#include <limits>
+#include <random>
+#include <chrono>
+#include <stdexcept> // required for std::runtime_error
+#include <set>
+
+#include "sparse_matrix_base.hpp"
+#include "gf2sparse.hpp"
+#include "rng.hpp"
+
+namespace ldpc::bp {
+
+    enum BpMethod {
+        PRODUCT_SUM = 0,
+        MINIMUM_SUM = 1
+    };
+
+    enum BpSchedule {
+        SERIAL = 0,
+        PARALLEL = 1,
+        SERIAL_RELATIVE = 2
+    };
+
+    enum BpInputType {
+        SYNDROME = 0,
+        RECEIVED_VECTOR = 1,
+        AUTO = 2
+    };
+
+    const std::vector<int> NULL_INT_VECTOR = {};
+
+    class BpEntry : public ldpc::sparse_matrix_base::EntryBase<BpEntry> {
+    public:
+        double bit_to_check_msg = 0.0;
+        double check_to_bit_msg = 0.0;
+
+        ~BpEntry() = default;
+    };
+
+
+    typedef ldpc::gf2sparse::GF2Sparse<BpEntry> BpSparse;
+
+
+    class BpDecoder {
+        // TODO properties should be private and only accessible via getters and setters
+    public:
+        BpSparse &pcm;
+        std::vector<double> channel_probabilities;
+        int check_count;
+        int bit_count;
+        int maximum_iterations;
+        BpMethod bp_method;
+        BpSchedule schedule;
+        BpInputType bp_input_type;
+        double ms_scaling_factor;
+        std::vector<uint8_t> decoding;
+        std::vector<uint8_t> candidate_syndrome;
+
+        std::vector<double> log_prob_ratios;
+        std::vector<double> initial_log_prob_ratios;
+        std::vector<double> soft_syndrome;
+        std::vector<int> serial_schedule_order;
+        int iterations;
+        int omp_thread_count;
+        bool converge;
+        int random_schedule_seed;
+        bool random_schedule_at_every_iteration;
+        ldpc::rng::RandomListShuffle<int> rng_list_shuffle;
+
+        BpDecoder(
+                BpSparse &parity_check_matrix,
+                std::vector<double> channel_probabilities,
+                int maximum_iterations = 0,
+                BpMethod bp_method = PRODUCT_SUM,
+                BpSchedule schedule = PARALLEL,
+                double min_sum_scaling_factor = 0.625,
+                int omp_threads = 1,
+                std::vector<int> serial_schedule = NULL_INT_VECTOR,
+                int random_schedule_seed = -1, // TODO what should be default here? 0 is set but -1 is checked in decode method?
+                bool random_schedule_at_every_iteration = true,
+                BpInputType bp_input_type = AUTO) :
+                pcm(parity_check_matrix) //the parity check matrix is passed in by reference
+        {
+
+            this->check_count = pcm.m;
+            this->bit_count = pcm.n;
+            this->channel_probabilities = channel_probabilities;
+            this->ms_scaling_factor = min_sum_scaling_factor;
+            this->maximum_iterations = maximum_iterations;
+            this->initial_log_prob_ratios.resize(bit_count);
+            this->log_prob_ratios.resize(bit_count);
+            this->candidate_syndrome.resize(check_count);
+            this->decoding.resize(bit_count);
+            this->converge = 0;
+            this->bp_method = bp_method;
+            this->iterations = 0;
+            this->schedule = schedule;
+            this->omp_thread_count = omp_threads;
+            this->random_schedule_seed = random_schedule_seed;
+            this->random_schedule_at_every_iteration = random_schedule_at_every_iteration;
+            this->bp_input_type = bp_input_type;
+
+
+            if (this->channel_probabilities.size() != this->bit_count) {
+                throw std::runtime_error("Channel probabilities vector must have length equal to the number of bits");
+            }
+            if (serial_schedule != NULL_INT_VECTOR) {
+                this->serial_schedule_order = serial_schedule;
+                this->random_schedule_seed = -1;
+            } else {
+                this->serial_schedule_order.resize(bit_count);
+                for (int i = 0; i < bit_count; i++) {
+                    this->serial_schedule_order[i] = i;
+                }
+                this->rng_list_shuffle.seed(this->random_schedule_seed);
+            }
+
+            //Initialise OMP thread pool
+            // this->omp_thread_count = omp_threads;
+            // this->set_omp_thread_count(this->omp_thread_count);
+        }
+
+        ~BpDecoder() = default;
+
+        void set_omp_thread_count(int count) {
+            this->omp_thread_count = count;
+            // omp_set_num_threads(this->omp_thread_count);
+            // NotImplemented
+        }
+
+        void initialise_log_domain_bp() {
+            // initialise BP
+            for (int i = 0; i < this->bit_count; i++) {
+                this->initial_log_prob_ratios[i] = std::log(
+                        (1 - this->channel_probabilities[i]) / this->channel_probabilities[i]);
+
+                for (auto &e: this->pcm.iterate_column(i)) {
+                    e.bit_to_check_msg = this->initial_log_prob_ratios[i];
+                }
+            }
+        }
+
+        std::vector<uint8_t> decode(std::vector<uint8_t> &input_vector) {
+
+
+            if ((this->bp_input_type == AUTO && input_vector.size() == this->bit_count) ||
+                this->bp_input_type == RECEIVED_VECTOR) {
+                auto syndrome = pcm.mulvec(input_vector);
+                std::vector<uint8_t> rv_decoding;
+                if (schedule == PARALLEL) {
+                    rv_decoding = bp_decode_parallel(syndrome);
+                } else if (schedule == SERIAL || schedule == SERIAL_RELATIVE) {
+                    rv_decoding = bp_decode_serial(syndrome);
+                } else throw std::runtime_error("Invalid BP schedule");
+
+                for (int i = 0; i < this->bit_count; i++) {
+                    this->decoding[i] = rv_decoding[i] ^ input_vector[i];
+                }
+
+                return this->decoding;
+
+            }
+
+
+            if (schedule == PARALLEL) {
+                return bp_decode_parallel(input_vector);
+            } else if (schedule == SERIAL || schedule == SERIAL_RELATIVE) {
+                return bp_decode_serial(input_vector);
+            } else { throw std::runtime_error("Invalid BP schedule"); }
+
+        }
+
+        std::vector<uint8_t> &bp_decode_parallel(std::vector<uint8_t> &syndrome) {
+
+            this->converge = 0;
+
+            this->initialise_log_domain_bp();
+
+            //main interation loop
+            for (int it = 1; it <= this->maximum_iterations; it++) {
+
+                if (this->bp_method == PRODUCT_SUM) {
+                    for (int i = 0; i < this->check_count; i++) {
+                        this->candidate_syndrome[i] = 0;
+
+                        double temp = 1.0;
+                        for (auto &e: this->pcm.iterate_row(i)) {
+                            e.check_to_bit_msg = temp;
+                            temp *= std::tanh(e.bit_to_check_msg / 2);
+                        }
+
+                        temp = 1;
+                        for (auto &e: this->pcm.reverse_iterate_row(i)) {
+                            e.check_to_bit_msg *= temp;
+                            int message_sign = syndrome[i] ? -1.0 : 1.0;
+                            e.check_to_bit_msg =
+                                    message_sign * std::log((1 + e.check_to_bit_msg) / (1 - e.check_to_bit_msg));
+                            temp *= std::tanh(e.bit_to_check_msg / 2);
+                        }
+                    }
+                } else if (this->bp_method == MINIMUM_SUM) {
+                    //check to bit updates
+                    for (int i = 0; i < check_count; i++) {
+
+                        this->candidate_syndrome[i] = 0;
+                        int total_sgn;
+                        int sgn;
+                        total_sgn = syndrome[i];
+                        double temp = std::numeric_limits<double>::max();
+
+                        for (auto &e: this->pcm.iterate_row(i)) {
+                            if (e.bit_to_check_msg <= 0) total_sgn += 1;
+                            e.check_to_bit_msg = temp;
+                            double abs_bit_to_check_msg = std::abs(e.bit_to_check_msg);
+                            if (abs_bit_to_check_msg < temp) {
+                                temp = abs_bit_to_check_msg;
+                            }
+                        }
+
+                        temp = std::numeric_limits<double>::max();
+                        for (auto &e: this->pcm.reverse_iterate_row(i)) {
+                            sgn = total_sgn;
+                            if (e.bit_to_check_msg <= 0) sgn += 1;
+                            if (temp < e.check_to_bit_msg) {
+                                e.check_to_bit_msg = temp;
+                            }
+
+                            int message_sign = (sgn % 2 == 0) ? 1.0 : -1.0;
+                            e.check_to_bit_msg *= message_sign * ms_scaling_factor;
+
+                            double abs_bit_to_check_msg = std::abs(e.bit_to_check_msg);
+                            if (abs_bit_to_check_msg < temp) {
+                                temp = abs_bit_to_check_msg;
+                            }
+
+                        }
+
+                    }
+                }
+
+
+                //compute log probability ratios
+                for (int i = 0; i < this->bit_count; i++) {
+                    double temp = initial_log_prob_ratios[i];
+                    for (auto &e: this->pcm.iterate_column(i)) {
+                        e.bit_to_check_msg = temp;
+                        temp += e.check_to_bit_msg;
+                        // if(isnan(temp)) temp = e.bit_to_check_msg;
+
+
+                    }
+
+                    //make hard decision on basis of log probability ratio for bit i
+                    this->log_prob_ratios[i] = temp;
+                    // if(isnan(log_prob_ratios[i])) log_prob_ratios[i] = initial_log_prob_ratios[i];
+                    if (temp <= 0) {
+                        this->decoding[i] = 1;
+                        for (auto &e: this->pcm.iterate_column(i)) {
+                            this->candidate_syndrome[e.row_index] ^= 1;
+                        }
+                    } else this->decoding[i] = 0;
+                }
+
+                if (std::equal(candidate_syndrome.begin(), candidate_syndrome.end(), syndrome.begin())) {
+                    this->converge = true;
+                }
+
+                this->iterations = it;
+
+                if (this->converge) return this->decoding;
+
+
+                //compute bit to check update
+                for (int i = 0; i < bit_count; i++) {
+                    double temp = 0;
+                    for (auto &e: this->pcm.reverse_iterate_column(i)) {
+                        e.bit_to_check_msg += temp;
+                        temp += e.check_to_bit_msg;
+                    }
+                }
+
+            }
+
+
+            return this->decoding;
+
+        }
+
+        std::vector<uint8_t> &bp_decode_single_scan(std::vector<uint8_t> &syndrome) {
+
+            converge = 0;
+            int CONVERGED = false;
+
+            std::vector<double> log_prob_ratios_old;
+            log_prob_ratios_old.resize(bit_count);
+
+            for (int i = 0; i < bit_count; i++) {
+                this->initial_log_prob_ratios[i] = std::log(
+                        (1 - this->channel_probabilities[i]) / this->channel_probabilities[i]);
+                this->log_prob_ratios[i] = this->initial_log_prob_ratios[i];
+
+            }
+
+            // initialise_log_domain_bp();
+
+            //main interation loop
+            for (int it = 1; it <= maximum_iterations; it++) {
+
+                if (CONVERGED) continue;
+
+                // std::fill(candidate_syndrome.begin(), candidate_syndrome.end(), 0);
+
+                log_prob_ratios_old = this->log_prob_ratios;
+
+                if (it != 1) {
+                    this->log_prob_ratios = this->initial_log_prob_ratios;
+                }
+
+                //check to bit updates
+                for (int i = 0; i < check_count; i++) {
+
+                    this->candidate_syndrome[i] = 0;
+
+                    int total_sgn, sgn;
+                    total_sgn = syndrome[i];
+                    double temp = std::numeric_limits<double>::max();
+
+                    double bit_to_check_msg;
+
+                    for (auto &e: pcm.iterate_row(i)) {
+                        if (it == 1) e.check_to_bit_msg = 0;
+                        bit_to_check_msg = log_prob_ratios_old[e.col_index] - e.check_to_bit_msg;
+                        if (bit_to_check_msg <= 0) total_sgn += 1;
+                        e.bit_to_check_msg = temp;
+                        double abs_bit_to_check_msg = std::abs(bit_to_check_msg);
+                        if (abs_bit_to_check_msg < temp) {
+                            temp = abs_bit_to_check_msg;
+                        }
+                    }
+
+                    temp = std::numeric_limits<double>::max();
+                    for (auto &e: pcm.reverse_iterate_row(i)) {
+                        sgn = total_sgn;
+                        if (it == 1) e.check_to_bit_msg = 0;
+                        bit_to_check_msg = log_prob_ratios_old[e.col_index] - e.check_to_bit_msg;
+                        if (bit_to_check_msg <= 0) sgn += 1;
+                        if (temp < e.bit_to_check_msg) {
+                            e.bit_to_check_msg = temp;
+                        }
+
+                        int message_sign = (sgn % 2 == 0) ? 1.0 : -1.0;
+                        e.check_to_bit_msg = message_sign * ms_scaling_factor * e.bit_to_check_msg;
+                        this->log_prob_ratios[e.col_index] += e.check_to_bit_msg;
+
+
+                        double abs_bit_to_check_msg = std::abs(bit_to_check_msg);
+                        if (abs_bit_to_check_msg < temp) {
+                            temp = abs_bit_to_check_msg;
+                        }
+
+                    }
+
+
+                }
+
+
+
+                //compute hard decisions and calculate syndrome
+                for (int i = 0; i < bit_count; i++) {
+                    if (this->log_prob_ratios[i] <= 0) {
+                        this->decoding[i] = 1;
+                        for (auto &e: pcm.iterate_column(i)) {
+                            this->candidate_syndrome[e.row_index] ^= 1;
+                        }
+                    } else this->decoding[i] = 0;
+                }
+
+                int loop_break = false;
+                CONVERGED = false;
+
+                if (std::equal(candidate_syndrome.begin(), candidate_syndrome.end(), syndrome.begin())) {
+                    CONVERGED = true;
+                }
+
+                iterations = it;
+
+                if (CONVERGED) {
+                    converge = CONVERGED;
+                    return decoding;
+                }
+
+            }
+
+
+            converge = CONVERGED;
+            return decoding;
+
+        }
+
+        std::vector<uint8_t> &bp_decode_serial(std::vector<uint8_t> &syndrome) {
+            int check_index;
+            this->converge = false;
+            // initialise BP
+            this->initialise_log_domain_bp();
+
+            for (int it = 1; it <= maximum_iterations; it++) {
+                if (this->random_schedule_seed > -1) {
+                    this->rng_list_shuffle.shuffle(this->serial_schedule_order);
+                } else if (this->schedule == BpSchedule::SERIAL_RELATIVE) {
+                    // resort by LLRs in each iteration to ensure that the most reliable bits are considered first
+                    std::sort(this->serial_schedule_order.begin(), this->serial_schedule_order.end(),
+                              [this, it](int bit1, int bit2) {
+                                  if (it != 1) {
+                                      return this->log_prob_ratios[bit1] > this->log_prob_ratios[bit2];
+                                  } else {
+                                      return std::log((1 - channel_probabilities[bit1]) / channel_probabilities[bit1]) >
+                                             std::log((1 - channel_probabilities[bit2]) / channel_probabilities[bit2]);
+                                  }
+                              });
+                }
+
+                for (int bit_index: this->serial_schedule_order) {
+                    double temp;
+                    this->log_prob_ratios[bit_index] = std::log(
+                            (1 - channel_probabilities[bit_index]) / channel_probabilities[bit_index]);
+                    if (this->bp_method == 0) {
+                        for (auto &e: this->pcm.iterate_column(bit_index)) {
+                            check_index = e.row_index;
+                            e.check_to_bit_msg = 1.0;
+                            for (auto &g: this->pcm.iterate_row(check_index)) {
+                                if (&g != &e) {
+                                    e.check_to_bit_msg *= tanh(g.bit_to_check_msg / 2);
+                                }
+                            }
+                            e.check_to_bit_msg = pow(-1, syndrome[check_index]) *
+                                                 std::log((1 + e.check_to_bit_msg) / (1 - e.check_to_bit_msg));
+                            e.bit_to_check_msg = log_prob_ratios[bit_index];
+                            this->log_prob_ratios[bit_index] += e.check_to_bit_msg;
+                        }
+                    } else if (this->bp_method == 1) {
+                        for (auto &e: pcm.iterate_column(bit_index)) {
+                            check_index = e.row_index;
+                            int sgn = syndrome[check_index];
+                            temp = std::numeric_limits<double>::max();
+                            for (auto &g: this->pcm.iterate_row(check_index)) {
+                                if (&g != &e) {
+                                    double abs_bit_to_check_msg = std::abs(g.bit_to_check_msg);
+                                    if (abs_bit_to_check_msg < temp) temp = abs_bit_to_check_msg;
+                                    if (g.bit_to_check_msg <= 0) sgn += 1;
+                                }
+                            }
+                            double message_sign = (sgn % 2 == 0) ? 1.0 : -1.0;
+                            e.check_to_bit_msg = ms_scaling_factor * message_sign * temp;
+                            e.bit_to_check_msg = log_prob_ratios[bit_index];
+                            this->log_prob_ratios[bit_index] += e.check_to_bit_msg;
+                        }
+                    }
+                    if (this->log_prob_ratios[bit_index] <= 0) {
+                        this->decoding[bit_index] = 1;
+                    } else {
+                        this->decoding[bit_index] = 0;
+                    }
+                    temp = 0;
+                    for (auto &e: this->pcm.reverse_iterate_column(bit_index)) {
+                        e.bit_to_check_msg += temp;
+                        temp += e.check_to_bit_msg;
+                    }
+                }
+
+                // compute the syndrome for the current candidate decoding solution
+                this->candidate_syndrome = pcm.mulvec(decoding, candidate_syndrome);
+                this->iterations = it;
+                if (std::equal(candidate_syndrome.begin(), candidate_syndrome.end(), syndrome.begin())) {
+                    this->converge = true;
+                    return this->decoding;
+                }
+            }
+            return this->decoding;
+        }
+
+        std::vector<uint8_t> &
+        soft_info_decode_serial(std::vector<double> &soft_info_syndrome, double cutoff, double sigma) {
+            // compute the syndrome log-likelihoods and initialize hard syndrome
+            std::vector<uint8_t> syndrome;
+            this->soft_syndrome = soft_info_syndrome;
+            for (int i = 0; i < this->check_count; i++) {
+                this->soft_syndrome[i] = 2 * this->soft_syndrome[i] / (sigma * sigma);
+                if (this->soft_syndrome[i] <= 0) {
+                    syndrome.push_back(1);
+                } else {
+                    syndrome.push_back(0);
+                }
+            }
+
+            int check_index;
+            this->converge = false;
+            bool CONVERGED = false;
+            bool loop_break = false;
+            // initialise BP
+            this->initialise_log_domain_bp();
+            std::set<int> check_indices_updated;
+
+            for (int it = 1; it <= maximum_iterations; it++) {
+                if (CONVERGED) {
+                    continue;
+                }
+                if (this->random_schedule_at_every_iteration && omp_thread_count == 1) {
+                    // reorder schedule elements randomly
+                    shuffle(serial_schedule_order.begin(), serial_schedule_order.end(),
+                            std::default_random_engine(random_schedule_seed));
+                }
+
+                check_indices_updated.clear();
+                for (auto bit_index: serial_schedule_order) {
+                    double temp;
+                    log_prob_ratios[bit_index] = std::log(
+                            (1 - channel_probabilities[bit_index]) / channel_probabilities[bit_index]);
+                    for (auto &check_nbr: pcm.iterate_column(bit_index)) {
+                        // first, we compute the min absolute value of neighbours excluding the current recipient
+                        check_index = check_nbr.row_index;
+                        int sgn = 0;
+                        temp = std::numeric_limits<double>::max();
+                        for (auto &g: pcm.iterate_row(check_index)) {
+                            if (&g != &check_nbr) {
+                                if (std::abs(g.bit_to_check_msg) < temp) {
+                                    temp = std::abs(g.bit_to_check_msg);
+                                }
+                                if (g.bit_to_check_msg <= 0) {
+                                    sgn ^= 1;
+                                }
+                            }
+                        }
+                        double min_bit_to_check_msg = temp;
+                        double propagated_msg = min_bit_to_check_msg;
+                        double soft_syndrome_magnitude = std::abs(this->soft_syndrome[check_index]);
+
+                        // if the soft syndrome magnitude is below cutoff, we apply the virtual update rules
+                        if (soft_syndrome_magnitude < cutoff) {
+                            if (soft_syndrome_magnitude < std::abs(min_bit_to_check_msg)) {
+                                propagated_msg = soft_syndrome_magnitude;
+                                int check_node_sgn = sgn;
+                                if (check_nbr.bit_to_check_msg <= 0) {
+                                    check_node_sgn ^= 1;
+                                }
+                                // now we check whether we have to update the soft syndrome magnitude and sign
+                                if (check_node_sgn == syndrome[check_index]) {
+                                    if (std::abs(check_nbr.bit_to_check_msg) < min_bit_to_check_msg) {
+                                        this->soft_syndrome[check_index] =
+                                                pow(-1, syndrome[check_index]) *
+                                                std::abs(check_nbr.bit_to_check_msg);
+                                    } else {
+                                        this->soft_syndrome[check_index] =
+                                                pow(-1, syndrome[check_index]) * min_bit_to_check_msg;
+                                    }
+                                } else {
+                                    syndrome[check_index] ^= 1;
+                                    this->soft_syndrome[check_index] *= -1;
+                                }
+                            }
+                        }
+                        sgn ^= syndrome[check_index];
+                        check_nbr.check_to_bit_msg = ms_scaling_factor * pow(-1, sgn) * propagated_msg;
+                        check_nbr.bit_to_check_msg = log_prob_ratios[bit_index];
+                        log_prob_ratios[bit_index] += check_nbr.check_to_bit_msg;
+                    }
+                    // hard decision on bit
+                    if (log_prob_ratios[bit_index] <= 0) {
+                        decoding[bit_index] = 1;
+                    } else {
+                        decoding[bit_index] = 0;
+                    }
+                    temp = 0;
+                    for (auto &e: pcm.reverse_iterate_column(bit_index)) {
+                        e.bit_to_check_msg += temp;
+                        temp += e.check_to_bit_msg;
+                    }
+                }
+                // compute the syndrome for the current candidate decoding solution
+                loop_break = false;
+                CONVERGED = true;
+                for (auto i = 0; i < soft_info_syndrome.size(); i++) {
+                    if (soft_info_syndrome[i] <= 0) {
+                        candidate_syndrome[i] = 1;
+                    } else {
+                        candidate_syndrome[i] = 0;
+                    }
+                }
+                candidate_syndrome = pcm.mulvec(decoding, candidate_syndrome);
+                for (auto i = 0; i < check_count && !loop_break; i++) {
+                    if (candidate_syndrome[i] != syndrome[i]) {
+                        CONVERGED = false;
+                        loop_break = true;
+                    }
+                }
+                iterations = it;
+            }
+            converge = CONVERGED;
+            return decoding;
+        }
+    };
+} // end namespace bp
+
+#endif

--- a/src/ldpc_v2_src/gf2sparse.hpp
+++ b/src/ldpc_v2_src/gf2sparse.hpp
@@ -1,0 +1,601 @@
+/**
+ * @file gf2sparse.h
+ * @brief A C++ library for sparse matrices in GF(2)
+ */
+
+#ifndef GF2SPARSE_H
+#define GF2SPARSE_H
+
+#include <vector>
+#include <iterator>
+#include "sparse_matrix_base.hpp"
+
+namespace ldpc{
+namespace gf2sparse{
+
+/**
+ * @brief An entry in a sparse matrix over GF(2)
+ */
+class GF2Entry: public ldpc::sparse_matrix_base::EntryBase<GF2Entry>{ 
+    public: 
+        ~GF2Entry() = default;
+};
+
+/**
+ * @brief A sparse matrix over GF(2)
+ */
+template <class ENTRY_OBJ = GF2Entry>
+class GF2Sparse: public ldpc::sparse_matrix_base::SparseMatrixBase<ENTRY_OBJ>{
+    public:
+        typedef ldpc::sparse_matrix_base::SparseMatrixBase<ENTRY_OBJ> BASE;
+
+        /**
+         * @brief Constructor for creating a new GF2Sparse object with the given dimensions
+         * @param rows The number of rows in the matrix
+         * @param cols The number of columns in the matrix
+         */
+        GF2Sparse(int rows, int cols, int entry_count = 0): ldpc::sparse_matrix_base::SparseMatrixBase<ENTRY_OBJ>(rows, cols, entry_count){}
+        
+        
+        /**
+         * @brief Default constructor for creating a new GF2Sparse object.
+         *        Creates an empty GF2Sparse matrix with zero rows and columns.
+         */
+        GF2Sparse() = default;
+
+
+        /**
+         * @brief Destructor for GF2Sparse object
+         */
+        ~GF2Sparse() = default;
+
+        /**
+         * @brief Inserts a row of entries in compressed sparse row (CSR) format
+         * @param row_index The index of the row to insert
+         * @param column_indices The indices of the non-zero entries in the row
+         */
+        void csr_row_insert(int row_index, std::vector<int>& column_indices);
+
+        /**
+         * @brief Inserts a matrix in CSR format
+         * @param csr_matrix The matrix to insert
+         */
+        void csr_insert(std::vector<std::vector<int>>& csr_matrix);
+
+        /**
+         * @brief Inserts a matrix in CSR format
+         * @param csr_matrix The matrix to insert
+         */
+        void csc_insert(std::vector<std::vector<int>>& csc_matrix);
+
+        /**
+         * @brief Multiplies the matrix by a vector and stores the result in another vector
+         * @param input_vector The vector to multiply the matrix with
+         * @param output_vector The vector to store the result in
+         * @return A reference to the output vector
+         */
+        std::vector<uint8_t>& mulvec(std::vector<uint8_t>& input_vector, std::vector<uint8_t>& output_vector);
+
+        /**
+         * @brief Multiplies the matrix by a vector and returns the result as a new vector
+         * @param input_vector The vector to multiply the matrix with
+         * @return The resulting vector
+         */
+        std::vector<uint8_t> mulvec(std::vector<uint8_t>& input_vector);
+
+        // /**
+        //  * @brief Multiplies the matrix by a vector with parallel execution using OpenMP and stores the result in another vector
+        //  * @param input_vector The vector to multiply the matrix with
+        //  * @param output_vector The vector to store the result in
+        //  * @return A reference to the output vector
+        //  */
+        // std::vector<uint8_t>& mulvec_parallel(std::vector<uint8_t>& input_vector, std::vector<uint8_t>& output_vector);
+
+        /**
+         * @brief Multiplies the matrix by another matrix and returns the result as a new matrix
+         * @tparam ENTRY_OBJ2 The type of entries in the matrix to be multiplied with
+         * @param mat_right The matrix to multiply with
+         * @return The resulting matrix
+         */
+        template<typename ENTRY_OBJ2>
+        GF2Sparse<ENTRY_OBJ> matmul(GF2Sparse<ENTRY_OBJ2>& mat_right);
+
+        /**
+         * @brief Adds two rows together
+         * @param i The row to overwrite
+         * @param j The row to add to row i
+         */
+        void add_rows(int i, int j);
+
+        /**
+         * @brief Transposes the matrix
+         * @return The transposed matrix
+         */
+        GF2Sparse<ENTRY_OBJ> transpose();
+
+        /**
+         * @brief Compares two matrices for equality
+         * @tparam ENTRY_OBJ2 The type of entries in the matrix to compare with
+         * @param matrix2 The matrix to compare with
+         * @return True if the matrices are equal, false otherwise
+         */
+        template <typename ENTRY_OBJ2>
+        bool gf2_equal(GF2Sparse<ENTRY_OBJ2>& matrix2);
+
+        /**
+         * @brief Allocates memory for the sparse matrix
+         * 
+         * @param m The row count
+         * @param n The column count
+         * @param entry_count The number of entries in the matrix (optional)
+         * @return ** void 
+         */
+        void allocate(int m, int n, int entry_count = 0);
+
+};
+
+template<class ENTRY_OBJ>
+void GF2Sparse<ENTRY_OBJ>::allocate(int m, int n, int entry_count){
+    this->initialise_sparse_matrix(m,n,entry_count);
+}
+
+template<class ENTRY_OBJ>
+void GF2Sparse<ENTRY_OBJ>::csr_row_insert(int row_index, std::vector<int>& column_indices){
+    // Iterate through each column index in the vector
+    for(auto col_index: column_indices){
+        // Insert a new entry with the given row and column indices
+        this->insert_entry(row_index,col_index);
+    }
+}
+
+template<class ENTRY_OBJ>
+void GF2Sparse<ENTRY_OBJ>::csr_insert(std::vector<std::vector<int>>& csr_matrix){
+    int i = 0;
+    // Iterate through each row of the matrix
+    for(auto row: csr_matrix){
+        // Insert the row of entries in compressed sparse row (CSR) format
+        this->csr_row_insert(i, row);
+        i++;
+    }
+}
+
+template<class ENTRY_OBJ>
+void GF2Sparse<ENTRY_OBJ>::csc_insert(std::vector<std::vector<int>>& csc_matrix){
+    int i = 0;
+    // Iterate through each column of the matrix
+    for(auto col: csc_matrix){
+        // Insert the column of entries in compressed sparse column (CSC) format
+        for(auto row_index: col){
+            this->insert_entry(row_index,i);
+        }
+        i++;
+    }
+}
+
+
+template <class ENTRY_OBJ>
+std::vector<uint8_t>& GF2Sparse<ENTRY_OBJ>::mulvec(std::vector<uint8_t>& input_vector, std::vector<uint8_t>& output_vector){
+    // Initialize the output vector to all zeros
+    for(int i = 0; i<this->m; i++) output_vector[i] = 0;
+
+    // Iterate through each row of the matrix
+    for(int i = 0; i < this->m; i++){
+        // Iterate through each non-zero entry in the row
+        for(auto& e: this->iterate_row(i)){
+            // Compute the XOR of the current output value with the value in the input vector at the entry's column index
+            output_vector[i] ^= input_vector[e.col_index];
+        }
+    }
+
+    // Return the output vector
+    return output_vector;
+}
+
+template<class ENTRY_OBJ>
+std::vector<uint8_t> GF2Sparse<ENTRY_OBJ>::mulvec(std::vector<uint8_t>& input_vector){
+    // Initialize the output vector to all zeros
+    std::vector<uint8_t> output_vector(this->m,0);
+
+    // Iterate through each row of the matrix
+    for(int i = 0; i < this->m; i++){
+        // Iterate through each non-zero entry in the row
+        for(auto& e: this->iterate_row(i)){
+            // Compute the XOR of the current output value with the value in the input vector at the entry's column index
+            output_vector[i] ^= input_vector[e.col_index];
+        }
+    }
+
+    // Return the output vector
+    return output_vector;
+}
+
+
+// template<class ENTRY_OBJ>
+// std::vector<uint8_t>& GF2Sparse<ENTRY_OBJ>::mulvec_parallel(std::vector<uint8_t>& input_vector, std::vector<uint8_t>& output_vector){
+//     // Initialize the output vector to all zeros
+//     #pragma omp for
+//     for(int i = 0; i<this->m; i++) output_vector[i] = 0;
+
+//     // Iterate through each row of the matrix
+//     #pragma omp for
+//     for(int i = 0; i < this->m; i++){
+//         // Iterate through each non-zero entry in the row
+//         for(auto& e: this->iterate_row(i)){
+//             // Compute the XOR of the current output value with the value in the input vector at the entry's column index
+//             output_vector[i] ^= input_vector[e.col_index];
+//         }
+//     }
+
+//     // Return the output vector
+//     return output_vector;
+// }
+
+
+template<typename ENTRY_OBJ>
+template<typename ENTRY_OBJ2>
+GF2Sparse<ENTRY_OBJ> GF2Sparse<ENTRY_OBJ>::matmul(GF2Sparse<ENTRY_OBJ2>& mat_right) {
+
+    // Check if the dimensions of the input matrices are valid for multiplication
+    if( this->n!=mat_right.m){
+        throw std::invalid_argument("Input matrices have invalid dimensions!");
+    }
+
+    // Create a new GF2Sparse matrix to store the output
+    auto output_mat = GF2Sparse<ENTRY_OBJ>(this->m,mat_right.n);
+
+    // Iterate over each row and column of the output matrix
+    for(int i = 0; i<output_mat.m; i++){
+        for(int j = 0; j<output_mat.n; j++){
+            int sum = 0;
+            // Iterate over the non-zero entries in the column of the right-hand matrix
+            for(auto& e: mat_right.iterate_column(j)){
+                // Iterate over the non-zero entries in the row of this matrix
+                for(auto& g: this->iterate_row(i)){
+                    // Check if the column index of this matrix matches the row index of the right-hand matrix
+                    if(g.col_index == e.row_index) sum^=1;
+                }
+            }
+            // Insert an entry in the output matrix if the sum is non-zero
+            if(sum) output_mat.insert_entry(i,j);
+        }
+    }
+
+    // Return a shared pointer to the output matrix
+    return output_mat;
+}
+
+
+template<class ENTRY_OBJ>
+void GF2Sparse<ENTRY_OBJ>::add_rows(int i, int j){
+
+    // Set row i as the row that will be overwritten
+    // Initialize variables
+    bool intersection;
+    std::vector<ENTRY_OBJ*> entries_to_remove;
+
+    for(auto& g: this->iterate_row(j)){
+        intersection=false;
+        int col_index = g.col_index;
+        for(auto& e: this->iterate_column(col_index)){
+            if(e.row_index==i){
+                entries_to_remove.push_back(&e);
+                intersection=true;
+            }
+        }
+        // If there was no intersection between the entries, insert the entry from row j into row i
+        if(!intersection){
+            this->insert_entry(i,col_index);
+        }
+
+    }
+
+    // Remove all the entries from row i that were marked for removal
+    for(auto e: entries_to_remove) this->remove(*e);
+
+}
+
+template<class ENTRY_OBJ>
+GF2Sparse<ENTRY_OBJ> GF2Sparse<ENTRY_OBJ>::transpose(){
+
+    // Create a new GF2Sparse matrix with the dimensions of the transposed matrix
+    auto pcmT = GF2Sparse<ENTRY_OBJ>(this->n,this->m);
+
+    // Iterate over each row of this matrix
+    for(int i = 0; i<this->m; i++){
+        // Iterate over each non-zero entry in the row
+        for(auto& e: this->iterate_row(i)){
+            // Insert the entry into the transposed matrix with the row and column indices swapped
+            pcmT.insert_entry(e.col_index,e.row_index);
+        }
+    }
+
+    // Return a shared pointer to the transposed matrix
+    return pcmT;
+}
+
+template<class ENTRY_OBJ>
+template <typename ENTRY_OBJ2>
+bool GF2Sparse<ENTRY_OBJ>::gf2_equal(GF2Sparse<ENTRY_OBJ2>& matrix2){
+
+    // Check if the dimensions of the matrices are equal
+    if(this->n!=matrix2.n || this->m!=matrix2.m) return false;
+
+    // Iterate over each row of this matrix
+    for(int i = 0; i<this->m; i++){
+
+        // Iterate over each non-zero entry in the row of this matrix
+        for(auto& e: this->iterate_row(i)){
+
+            // Get the corresponding entry in the same position of the other matrix
+            auto& g = matrix2.get_entry(e.row_index,e.col_index);
+
+            // If there is no corresponding entry in the same position of the other matrix, the matrices are not equal
+            if(g.at_end()) return false;
+        }
+
+        // Iterate over each non-zero entry in the row of the other matrix
+        for(auto& e: matrix2.iterate_row(i)){
+
+            // Get the corresponding entry in the same position of this matrix
+            auto& g = this->get_entry(e.row_index,e.col_index);
+
+            // If there is no corresponding entry in the same position of this matrix, the matrices are not equal
+            if(g.at_end()) return false;
+        }
+    }
+
+    // If all non-zero entries in both matrices are the same, the matrices are equal
+    return true;
+}
+
+/**
+ * @brief Compares two GF2Sparse matrices for equality
+ * @tparam ENTRY_OBJ1 The type of entries in the first matrix
+ * @tparam ENTRY_OBJ2 The type of entries in the second matrix
+ * @param matrix1 A shared pointer to the first matrix
+ * @param matrix2 A shared pointer to the second matrix
+ * @return True if the matrices are equal, false otherwise
+ */
+template <typename ENTRY_OBJ1, typename ENTRY_OBJ2>
+bool operator==(GF2Sparse<ENTRY_OBJ1>& matrix1, GF2Sparse<ENTRY_OBJ2>& matrix2){
+    return matrix1.gf2_equal(matrix2);
+}
+
+/**
+ * @brief Creates a new GF2Sparse identity matrix with the given dimensions
+ * @tparam ENTRY_OBJ The type of entries in the matrix
+ * @param n The number of rows/columns in the matrix
+ * @return The GF2Sparse identity matrix
+ */
+template <class ENTRY_OBJ = GF2Entry>
+GF2Sparse<ENTRY_OBJ> identity(int n){
+    // Create a new GF2Sparse matrix with the given dimensions
+    auto matrix = GF2Sparse<ENTRY_OBJ>(n,n);
+
+    // Insert non-zero entries along the diagonal
+    for(int i = 0; i<n; i++) matrix.insert_entry(i,i);
+
+    // Return a shared pointer to the new GF2Sparse identity matrix
+    return matrix;
+}
+
+
+template <class GF2SPARSE_MATRIX_CLASS>
+GF2SPARSE_MATRIX_CLASS copy_cols(GF2SPARSE_MATRIX_CLASS& mat, std::vector<int> cols){
+    int m,n,i,j;
+    m = mat.m;
+    n = cols.size();
+    auto copy_mat = GF2SPARSE_MATRIX_CLASS(m,n);
+    int new_col_index=-1;
+    for(auto col_index: cols){
+        new_col_index+=1;
+        for(auto& e: mat.iterate_column(col_index)){
+            copy_mat.insert_entry(e.row_index,new_col_index);
+        }
+    }
+    return copy_mat;
+}
+
+
+template <class GF2MATRIX>
+GF2MATRIX vstack(std::vector<GF2MATRIX>& mats){
+
+    int mat_count = mats.size();
+    int n = mats[0].n;
+    int m0  = mats[0].m;
+
+    int m = 0;
+    for (auto mat: mats){
+        if(mat.n!=n) throw std::invalid_argument("All matrices must have the same number of columns");
+        m+=mat.m;
+    }
+
+    auto stacked_mat = GF2MATRIX(m,n);
+
+    int row_offset = 0;
+    for(auto mat: mats){
+        for(auto i=0; i<mat.m; i++){
+            for(auto& e: mat.iterate_row(i)){
+                stacked_mat.insert_entry(row_offset+e.row_index,e.col_index);
+            }
+        }
+        row_offset+=mat.m;
+    }
+
+    return stacked_mat;
+
+}
+
+template <class ENTRY_OBJ>
+GF2Sparse<ENTRY_OBJ> hstack(std::vector<GF2Sparse<ENTRY_OBJ>>& mats){
+    
+    int mat_count = mats.size();
+    int m = mats[0].m;
+
+    int n = 0;
+
+    for(auto mat: mats){
+        if(mat.m!=m) throw std::invalid_argument("All matrices must have the same number of rows");
+        n+=mat.n;
+    }
+
+    auto stacked_mat = GF2Sparse<ENTRY_OBJ>(m,n);
+
+    int col_offset = 0;
+    for(auto mat: mats){
+        for(auto i=0; i<mat.m; i++){
+            for(auto& e: mat.iterate_row(i)){
+                stacked_mat.insert_entry(e.row_index,col_offset+e.col_index);
+            }
+        }
+        col_offset+=mat.n;
+    }
+
+    return stacked_mat;
+
+    
+}
+
+template <class ENTRY_OBJ>
+GF2Sparse<ENTRY_OBJ> hstack(GF2Sparse<ENTRY_OBJ>& mat1, GF2Sparse<ENTRY_OBJ>& mat2){
+    
+    int m;
+    int n;
+
+    n = mat1.n + mat2.n;
+    m = mat1.m;
+    if(mat1.m != mat2.m) throw std::invalid_argument("All matrices must have the same number of rows");
+
+    auto stacked_mat = GF2Sparse<ENTRY_OBJ>(m,n);
+
+    for (int i =0; i<m; i++){
+        for(auto& e: mat1.iterate_row(i)){
+            stacked_mat.insert_entry(e.row_index,e.col_index);
+        }
+
+        for(auto& e: mat2.iterate_row(i)){
+            stacked_mat.insert_entry(e.row_index,e.col_index + mat1.n);
+        }
+    }
+
+    return stacked_mat;
+
+    
+}
+
+template <class GF2MATRIX>
+GF2MATRIX kron(GF2MATRIX& mat1, GF2MATRIX& mat2){
+    
+    int m1,n1,m2,n2;
+    m1 = mat1.m;
+    n1 = mat1.n;
+    m2 = mat2.m;
+    n2 = mat2.n;
+
+    auto kron_mat = GF2MATRIX(m1*m2,n1*n2);
+
+    for(auto i=0; i<m1; i++){
+        for(auto& e: mat1.iterate_row(i)){
+            int row_offset = e.row_index*m2;
+            int col_offset = e.col_index*n2;
+
+            for(auto j = 0; j<m2; j++){
+                for(auto& f: mat2.iterate_row(j)){
+                    kron_mat.insert_entry(row_offset+f.row_index,col_offset+f.col_index);
+                }
+            }
+
+        }
+        
+    }
+
+    return kron_mat;
+
+}
+
+template <class GF2MATRIX>
+GF2MATRIX operator+(GF2MATRIX& mat1, GF2MATRIX& mat2){
+    
+    if(mat1.m!=mat2.m || mat1.n!=mat2.n){
+        throw std::invalid_argument("Matrices must have the same dimensions");
+    }
+
+    //Deepcopy mat2
+    auto sum_mat = GF2Sparse(mat2.m,mat2.n);  
+    for(int i=0; i<mat2.m; i++){
+        for(auto& e: mat2.iterate_row(i)){
+            sum_mat.insert_entry(e.row_index,e.col_index);
+        }
+    }
+
+    // Add mat1 to mat2
+    for(int i=0; i<mat1.m; i++){
+        for(auto& e: mat1.iterate_row(i)){
+            auto& g = sum_mat.get_entry(e.row_index,e.col_index);
+            if(!g.at_end()){
+                sum_mat.remove(g);
+            }
+            else{
+                sum_mat.insert_entry(e.row_index,e.col_index);
+            }
+        }
+    }
+
+    return sum_mat;
+}
+
+
+template <class ENTRY_OBJ = GF2Entry>
+GF2Sparse<ENTRY_OBJ> csr_to_gf2sparse(std::vector<std::vector<int>>& csr_matrix){
+    int row_count = csr_matrix.size();
+    int col_count = 0;
+    for(auto row: csr_matrix){
+        for(auto col: row){
+            if(col>col_count) col_count = col;
+        }
+    }
+
+    auto gf2sparse_mat = GF2Sparse<ENTRY_OBJ>(row_count,col_count+1);
+
+    for(auto row_index = 0; row_index<row_count; row_index++){
+        for(auto col_index: csr_matrix[row_index]){
+            gf2sparse_mat.insert_entry(row_index,col_index);
+        }
+    }
+
+    return gf2sparse_mat;
+
+}
+
+template <class ENTRY_OBJ = GF2Entry>
+GF2Sparse<ENTRY_OBJ> csc_to_gf2sparse(std::vector<std::vector<int>>& csc_matrix){
+    int col_count = csc_matrix.size();
+    int row_count = 0;
+    for(auto col: csc_matrix){
+        for(auto row: col){
+            if(row>row_count) row_count = row;
+        }
+    }
+
+    auto gf2sparse_mat = GF2Sparse<ENTRY_OBJ>(row_count+1,col_count);
+
+    for(auto col_index = 0; col_index<col_count; col_index++){
+        for(auto row_index: csc_matrix[col_index]){
+            gf2sparse_mat.insert_entry(row_index,col_index);
+        }
+    }
+
+    return gf2sparse_mat;
+
+}
+
+
+
+} // end namespace gf2sparse
+} // end namespace ldpc
+
+
+typedef ldpc::gf2sparse::GF2Entry cygf2_entry;
+typedef ldpc::gf2sparse::GF2Sparse<ldpc::gf2sparse::GF2Entry> cygf2_sparse;
+
+#endif

--- a/src/ldpc_v2_src/rng.hpp
+++ b/src/ldpc_v2_src/rng.hpp
@@ -1,0 +1,138 @@
+/**
+ * @file rng.hpp
+ * @brief Defines the ldpc::rng::RandomNumberGenerator class, which generates random double values between 0 and 1
+ */
+
+#ifndef RNG_HPP
+#define RNG_HPP
+
+#include <random>
+#include <chrono> // for std::chrono::system_clock
+
+#include <algorithm>
+
+namespace ldpc::rng {
+
+    /**
+     * @brief Generates random double values between 0 and 1 using a Mersenne Twister random number generator
+     *
+     * The RandomNumberGenerator class creates a Mersenne Twister random number generator, and provides a method
+     * for generating random double values between 0 and 1 using a uniform distribution.
+     */
+    class RandomNumberGenerator {
+    public:
+        /**
+         * @brief Constructs a new RandomNumberGenerator object with an optional seed
+         *
+         * If no seed is specified, the generator is seeded using the system clock.
+         *
+         * @param seed The seed value to use for the random number generator
+         */
+        RandomNumberGenerator(int seed = 0) : gen(seed) {
+            if (seed == 0) {
+                gen.seed(std::chrono::system_clock::now().time_since_epoch().count());
+            }
+        }
+
+        ~RandomNumberGenerator() = default;
+        
+        /**
+         * @brief Generates a new random double value between 0 and 1
+         *
+         * @return A random double value between 0 and 1
+         */
+        double random_double() {
+            // Create a uniform distribution between 0 and 1
+            std::uniform_real_distribution<double> dis(0.0, 1.0);
+            
+            // Generate a random number between 0 and 1
+            double random_num = dis(gen);
+            
+            return random_num;
+        }
+
+        /**
+         * @brief Generates a new random integer value between 0 and max_int
+         *
+         * @param max_int The maximum value that the random integer can take
+         * @return A random integer value between 0 and max_int
+         */
+        int random_int(int max_int) {
+            // Create a uniform distribution between 0 and max_int
+            std::uniform_int_distribution<int> dis(0, max_int);
+            
+            // Generate a random number between 0 and max_int
+            int random_num = dis(gen);
+            
+            return random_num;
+        }
+        
+    private:
+        std::mt19937 gen; /**< The Mersenne Twister random number generator used by the class */
+    };
+
+
+    /**
+     * @brief A templated class for shuffling lists of data.
+     *
+     * This class provides the capability to shuffle lists of data of any type using a
+     * random number generator.
+     *
+     * @tparam T The type of data to shuffle.
+     */
+    template <typename T>
+    class RandomListShuffle {
+    public:
+        /**
+         * @brief Default constructor.
+         */
+        RandomListShuffle() = default;
+
+        /**
+         * @brief Constructor that allows specifying a seed.
+         *
+         * This constructor initializes the random number generator with the provided seed.
+         * If the seed is zero, it uses the system clock to generate a seed.
+         *
+         * @param seed The seed for the random number generator.
+         */
+        RandomListShuffle(unsigned int seed) {
+            this->seed(seed);
+        }
+
+        /**
+         * @brief Set the seed for the random number generator.
+         *
+         * This function allows you to set a custom seed for the random number generator.
+         * If the seed is zero, it uses the system clock to generate a seed.
+         *
+         * @param seed The seed for the random number generator.
+         */
+        void seed(unsigned int seed) {
+            if (seed == 0) {
+                // Use the system clock to generate a seed
+                auto now = std::chrono::system_clock::now();
+                seed = static_cast<unsigned int>(now.time_since_epoch().count());
+            }
+            generator.seed(seed);
+        }
+
+        /**
+         * @brief Shuffle a vector of data.
+         *
+         * This function shuffles the elements in the provided vector using the random
+         * number generator.
+         *
+         * @param data The vector of data to be shuffled.
+         */
+        void shuffle(std::vector<T>& data) {
+            std::shuffle(data.begin(), data.end(), generator);
+        }
+
+    private:
+        std::mt19937 generator; ///< The random number generator.
+    };
+
+} // namespace rng
+
+#endif // RNG_HPP

--- a/src/ldpc_v2_src/sparse_matrix_base.hpp
+++ b/src/ldpc_v2_src/sparse_matrix_base.hpp
@@ -1,0 +1,903 @@
+#ifndef SPARSE_MATRIX_BASE_H
+#define SPARSE_MATRIX_BASE_H
+
+#include <vector>
+#include <iterator>
+
+namespace ldpc {
+
+    namespace sparse_matrix_base {
+
+/**
+ * @brief Base class for defining the node types for Sparse Matrices
+ * 
+ * This class defines the basic properties of a node in a sparse matrix such as its row index, column index,
+ * and pointers to its neighboring nodes in the same row and column. Each node class that derives from this
+ * base class will inherit these properties and add any additional properties as required by the specific
+ * sparse matrix implementation.
+ * 
+ * @tparam DERIVED The derived class from EntryBase.
+ */
+        template<class DERIVED>
+        class EntryBase {
+        public:
+            int row_index = -100; /**< The row index of the matrix element */
+            int col_index = -100; /**< The column index of the matrix element */
+            DERIVED *left = static_cast<DERIVED *>(this); /**< Pointer to the previous element in the row */
+            DERIVED *right = static_cast<DERIVED *>(this); /**< Pointer to the next element in the row */
+            DERIVED *up = static_cast<DERIVED *>(this); /**< Pointer to the previous element in the column */
+            DERIVED *down = static_cast<DERIVED *>(this); /**< Pointer to the next element in the column */
+
+            /**
+             * @brief Resets the values of the entry to their default values.
+             *
+             * This function resets the values of the entry to their default values. This is useful for when an
+             * entry is removed from the matrix and needs to be returned to its default state for re-use.
+             */
+            void reset() {
+                row_index = -100;
+                col_index = -100;
+                left = static_cast<DERIVED *>(this);
+                right = static_cast<DERIVED *>(this);
+                up = static_cast<DERIVED *>(this);
+                down = static_cast<DERIVED *>(this);
+            }
+
+            /**
+             * @brief Checks if the entry is at the end of the list
+             *
+             * This function checks if the entry is at the end of the list by checking if its row index is equal
+             * to -100. If it is, then the function returns true to indicate that the entry is at the end of the
+             * list.
+             *
+             * @return True if the entry is at the end, false otherwise
+             */
+            bool at_end() {
+                if (row_index == -100) return true;
+                else return false;
+            }
+
+            /**
+             * @brief Returns a string representation of the entry
+             *
+             * This function returns a string representation of the entry. In this implementation, the function
+             * always returns "1", but in other implementations, this function could be used to return the value
+             * stored in the entry or some other useful information.
+             *
+             * @return The string representation of the entry
+             */
+            std::string str() {
+                return "1";
+            }
+
+        };
+
+
+        struct CsrMatrix {
+            int m;
+            int n;
+            int entry_count;
+            std::vector<std::vector<int>> row_adjacency_list;
+        };
+
+
+/**
+ * @brief Template base class for implementing sparse matrices in a doubly linked list format
+ * 
+ * @tparam ENTRY_OBJ The entry object class that the sparse matrix will use
+ * for its entries. This class should contain fields for row index, column index,
+ * and value.
+ * 
+ * This class allows for the construction of sparse matrices with custom data types by
+ * passing node objects via the ENTRY_OBJ template parameter. The matrix is stored as a
+ * doubly linked list, where each row and column is represented by a linked list of entries.
+ * Each entry contains a reference to the next and previous entries in its row and column,
+ * respectively. This format allows for efficient insertion and deletion of entries in the matrix,
+ * especially when the matrix is large and sparse.
+ */
+        template<class ENTRY_OBJ>
+        class SparseMatrixBase {
+        public:
+            int m, n; //m: check-count; n: bit-count // todo refactor to: check_cnt, bit_cnt
+            int node_count;
+            int entry_block_size;
+            int allocated_entry_count;
+            int released_entry_count;
+            int block_position;
+            int block_idx;
+            std::vector<std::vector<ENTRY_OBJ>> entries;
+            std::vector<ENTRY_OBJ *> removed_entries;
+            std::vector<ENTRY_OBJ *> row_heads; //starting point for each row
+            std::vector<ENTRY_OBJ *> column_heads; //starting point for each column
+            bool MEMORY_ALLOCATED = false;
+
+            // std::vector<ENTRY_OBJ*> matrix_entries;
+
+            SparseMatrixBase() = default;
+
+
+            SparseMatrixBase(int check_count, int bit_count, int entry_count = 0) {
+                this->initialise_sparse_matrix(check_count, bit_count, entry_count);
+            }
+
+            /**
+             * @brief Constructs a sparse matrix with the given dimensions
+             *
+             * @param check_count The number of rows in the matrix
+             * @param bit_count The number of columns in the matrix
+             */
+            void initialise_sparse_matrix(int check_count, int bit_count, int entry_count = 0) {
+
+                this->reset_matrix();
+                this->m = check_count;
+                this->n = bit_count;
+                this->block_idx = -1;
+                this->released_entry_count = 0;
+                this->allocated_entry_count = 0;
+                this->entry_block_size = this->m + this->n + entry_count;
+                this->allocate_memory();
+                this->entry_block_size = this->m + this->n;
+            }
+
+            void reset_matrix() {
+
+                if (this->MEMORY_ALLOCATED) {
+                    this->column_heads.clear();
+                    this->row_heads.clear();
+                    this->removed_entries.clear();
+                    for (auto entry_block: this->entries) entry_block.clear();
+                    this->entries.clear();
+                }
+                this->m = 0;
+                this->n = 0;
+                this->block_idx = -1;
+                this->released_entry_count = 0;
+                this->allocated_entry_count = 0;
+                this->entry_block_size = 0;
+                this->entry_block_size = 0;
+                this->MEMORY_ALLOCATED = false;
+            }
+
+            /**
+             * @brief Destructor for SparseMatrixBase. Frees memory occupied by entries.
+             */
+            ~SparseMatrixBase() {
+                this->reset_matrix();
+            }
+
+            /**
+             * @brief Allocates a new entry object and returns a pointer to it.
+             *
+             * If there are any entries that have been removed from the matrix, the function returns the last
+             * removed entry. Otherwise, if there is space in the entries vector, a new entry is allocated at
+             * the end of the vector. If the entries vector is full, the function allocates a new block of
+             * entries and returns the first entry in the new block.
+             *
+             * @return A pointer to a new entry object.
+             */
+            ENTRY_OBJ *allocate_new_entry() {
+                // if there are any previously removed entries, use them instead of creating new ones
+                if (this->removed_entries.size() != 0) {
+                    auto e_ptr = this->removed_entries.back();
+                    this->removed_entries.pop_back();
+                    return e_ptr;
+                }
+                // if there are no previously removed entries, create a new one
+                // if there is no space for the new entry, add a new block of entries
+                if (this->released_entry_count == this->allocated_entry_count) {
+                    this->entries.push_back(std::vector<ENTRY_OBJ>(this->entry_block_size));
+                    this->allocated_entry_count += this->entry_block_size;
+                    this->block_idx++;
+                    this->block_position = 0;
+                }
+
+
+
+                // use the next available entry in the pool
+                auto e_ptr = &this->entries[block_idx][this->block_position];
+                this->block_position++;
+                this->released_entry_count++;
+                return e_ptr;
+            }
+
+
+            /**
+             * @brief Returns the number of non-zero entries in the matrix.
+             *
+             * @return The number of non-zero entries in the matrix.
+             */
+            int entry_count() {
+                return this->released_entry_count - this->n - this->m - this->removed_entries.size();
+            }
+
+            /**
+             * @brief Computes the sparsity of the matrix
+             *
+             * The sparsity of a matrix is defined as the ratio of the number of zero elements in the
+             * matrix to the total number of elements in the matrix. This function computes the
+             * sparsity of the matrix represented by this object, and returns the result as a double value.
+             *
+             * @return The sparsity of the matrix as a double value.
+             */
+            const double sparsity() {
+                return double(this->entry_count()) / double(this->m * this->n);
+            }
+
+            /**
+            * @brief Allocates memory for the row and column header nodes.
+            *
+            * This function resizes the row_heads and column_heads vectors to m and n respectively.
+            * For each row and column header node, it allocates memory for a new entry object, sets
+            * the row and column indices to -100 to indicate it is not a value element, and sets the right,
+            * left, up, and down pointers to point to itself since there are no other nodes in the same row or column yet.
+            */
+            void allocate_memory() {
+
+                this->MEMORY_ALLOCATED = true;
+
+                this->row_heads.resize(this->m); // resize row_heads vector to m
+                this->column_heads.resize(this->n); // resize column_heads vector to n
+
+                // create and initialize each row header node
+                for (int i = 0; i < this->m; i++) {
+                    ENTRY_OBJ *row_entry_ptr = this->allocate_new_entry(); // allocate memory for a new entry object
+                    row_entry_ptr->row_index = -100; // set row index to -100 to indicate it is not a value element
+                    row_entry_ptr->col_index = -100; // set col index to -100 to indicate it is not a value element
+                    row_entry_ptr->right = row_entry_ptr; // point to itself since there are no other nodes in the same row yet
+                    row_entry_ptr->left = row_entry_ptr; // point to itself since there are no other nodes in the same row yet
+                    row_entry_ptr->up = row_entry_ptr; // point to itself since there are no other nodes in the same column yet
+                    row_entry_ptr->down = row_entry_ptr; // point to itself since there are no other nodes in the same column yet
+                    this->row_heads[i] = row_entry_ptr; // add the new row header node to the row_heads vector
+                }
+
+                // create and initialize each column header node
+                for (int i = 0; i < this->n; i++) {
+                    ENTRY_OBJ *col_entry_ptr = this->allocate_new_entry(); // allocate memory for a new entry object
+                    col_entry_ptr->row_index = -100; // set row index to -100 to indicate it is not a value element
+                    col_entry_ptr->col_index = -100; // set col index to -100 to indicate it is not a value element
+                    col_entry_ptr->right = col_entry_ptr; // point to itself since there are no other nodes in the same column yet
+                    col_entry_ptr->left = col_entry_ptr; // point to itself since there are no other nodes in the same column yet
+                    col_entry_ptr->up = col_entry_ptr; // point to itself since there are no other nodes in the same row yet
+                    col_entry_ptr->down = col_entry_ptr; // point to itself since there are no other nodes in the same row yet
+                    this->column_heads[i] = col_entry_ptr; // add the new column header node to the column_heads vector
+                }
+            }
+
+
+            /**
+             * @brief Swaps two rows of the matrix
+             *
+             * This function swaps rows i and j of the matrix. All row entries must be updated accordingly.
+             *
+             * @param i The index of the first row to swap
+             * @param j The index of the second row to swap
+             */
+            void swap_rows(int i, int j) {
+                auto tmp1_ptr = this->row_heads[i]; // store the head element of row i in a temporary variable
+                auto tmp2_ptr = this->row_heads[j]; // store the head element of row j in a temporary variable
+                this->row_heads[j] = tmp1_ptr; // set the head element of row j to the head element of row i
+                this->row_heads[i] = tmp2_ptr; // set the head element of row i to the head element of row j
+                for (auto &e: this->iterate_row(i))
+                    e.row_index = i; // update the row index of all elements in row i to j
+                for (auto &e: this->iterate_row(j))
+                    e.row_index = j; // update the row index of all elements in row j to i
+            }
+
+
+            void reorder_rows(std::vector<int> rows) {
+
+                std::vector<ENTRY_OBJ *> temp_row_heads = this->row_heads;
+                for (int i = 0; i < m; i++) {
+                    this->row_heads[i] = temp_row_heads[rows[i]];
+                    for (auto &e: this->iterate_row(i)) {
+                        e.row_index = i;
+                    }
+                }
+
+            }
+
+            /**
+             * Swaps two columns in the sparse matrix.
+             *
+             * @param i The index of the first column to swap.
+             * @param j The index of the second column to swap.
+             */
+            void swap_columns(int i, int j) {
+                auto tmp1 = this->column_heads[i];
+                auto tmp2 = this->column_heads[j];
+                this->column_heads[j] = tmp1;
+                this->column_heads[i] = tmp2;
+                // update the column indices for all entries in columns i and j
+                for (auto &e: this->iterate_column(i)) e.col_index = i;
+                for (auto &e: this->iterate_column(j)) e.col_index = j;
+            }
+
+            /**
+             * @brief Gets the number of non-zero entries in a row of the matrix.
+             *
+             * This function returns the degree of a given row in the matrix, i.e., the number of non-zero entries in the row.
+             *
+             * @param row The index of the row to get the degree of.
+             * @return The number of non-zero entries in the row.
+             */
+            int get_row_degree(int row) {
+                return abs(this->row_heads[row]->col_index) - 100;
+            }
+
+            /**
+             * @brief Gets the number of non-zero entries in a column of the matrix.
+             *
+             * This function returns the degree of a given column in the matrix, i.e., the number of non-zero entries in the column.
+             *
+             * @param col The index of the column to get the degree of.
+             * @return The number of non-zero entries in the column.
+             */
+            int get_col_degree(int col) {
+                return abs(this->column_heads[col]->col_index) - 100;
+            }
+
+            /**
+             * @brief Removes an entry from the matrix.
+             *
+             * This function removes a given entry from the matrix. The entry is identified by its row and column indices.
+             *
+             * @param i The row index of the entry to remove.
+             * @param j The column index of the entry to remove.
+             */
+            void remove_entry(int i, int j) {
+                auto &e = this->get_entry(i, j);
+                this->remove(e);
+            }
+
+            /**
+             * @brief Removes an entry from the matrix and updates the row/column weights
+             *
+             * @param e Pointer to the entry object to be removed
+             */
+            void remove(ENTRY_OBJ &e_ref) {
+                ENTRY_OBJ *e_ptr = &e_ref;
+                // Check if the entry is not already at the end of the row or column.
+                if (!e_ptr->at_end()) {
+                    // Store pointers to the adjacent entries.
+                    auto e_left_ptr = e_ptr->left;
+                    auto e_right_ptr = e_ptr->right;
+                    auto e_up_ptr = e_ptr->up;
+                    auto e_down_ptr = e_ptr->down;
+
+                    // Update pointers of the adjacent entries to remove the entry from the linked list.
+                    e_left_ptr->right = e_right_ptr;
+                    e_right_ptr->left = e_left_ptr;
+                    e_up_ptr->down = e_down_ptr;
+                    e_down_ptr->up = e_up_ptr;
+
+                    /* Update the row/column weights. Note that this information is stored in the
+                    ENTRY_OBJ.col_index field as a negative number (to avoid confusion with
+                    an actual column index). To get the row/column weights, use the get_row_weight()
+                    and get_col_weight() functions. */
+                    this->row_heads[e_ptr->row_index]->col_index++;
+                    this->column_heads[e_ptr->col_index]->col_index++;
+
+                    // Reset the entry to default values before pushing it to the buffer.
+                    e_ptr->reset();
+                    // Store the removed entry in the buffer for later reuse.
+                    this->removed_entries.push_back(e_ptr);
+                }
+            }
+
+            /**
+            * @brief Inserts a new entry in the matrix at position (j, i).
+            *
+            * @param j The row index of the new entry.
+            * @param i The column index of the new entry.
+            * @return A reference to the newly created ENTRY_OBJ object.
+            * @throws std::std::invalid_argument if either i or j is out of bounds.
+            *
+            * This function inserts a new entry in the matrix at position (j, i). If an entry
+            * already exists at that position, this function simply returns a reference to it.
+            * Otherwise, it creates a new entry and inserts it into the matrix, linking it to
+            * the neighboring entries to maintain the doubly linked structure. This function
+            * also updates the row and column weights of the matrix. The row and column weights
+            * are stored as negative integers in the col_index field of the ENTRY_OBJ object.
+            * To retrieve the actual weights, use the get_row_weight() and get_col_weight()
+            * functions.
+            */
+            ENTRY_OBJ &insert_entry(int j, int i) {
+                // std::cout<<i<<" "<<j<<std::endl;
+                // Check if indices are within bounds
+                if (j >= this->m || i >= this->n || j < 0 || i < 0)
+                    throw std::invalid_argument("Index i or j is out of bounds");
+
+                // Find the left and right entries in the jth row of the matrix
+                auto left_entry_ptr = this->row_heads[j];
+                auto right_entry_ptr = this->row_heads[j];
+                for (auto &entry: reverse_iterate_row(j)) {
+                    if (entry.col_index == i) {
+                        // Entry already exists at this position
+                        return entry;
+                    }
+                    if (entry.col_index > i) right_entry_ptr = &entry;
+                    if (entry.col_index < i) {
+                        left_entry_ptr = &entry;
+                        break;
+                    }
+                }
+
+                // Find the up and down entries in the ith column of the matrix
+                auto up_entry_ptr = this->column_heads[i];
+                auto down_entry_ptr = this->column_heads[i];
+                for (auto &entry: this->reverse_iterate_column(i)) {
+                    if (entry.row_index > j) down_entry_ptr = &entry;
+                    if (entry.row_index < j) {
+                        up_entry_ptr = &entry;
+                        break;
+                    }
+                }
+
+                // Create and link the new entry
+                auto e_ptr = this->allocate_new_entry();
+                node_count++;
+                e_ptr->row_index = j;
+                e_ptr->col_index = i;
+                e_ptr->right = right_entry_ptr;
+                e_ptr->left = left_entry_ptr;
+                e_ptr->up = up_entry_ptr;
+                e_ptr->down = down_entry_ptr;
+                left_entry_ptr->right = e_ptr;
+                right_entry_ptr->left = e_ptr;
+                up_entry_ptr->down = e_ptr;
+                down_entry_ptr->up = e_ptr;
+
+                // Update row and column weights
+                this->row_heads[e_ptr->row_index]->col_index--;
+                this->column_heads[e_ptr->col_index]->col_index--;
+
+                // Return a reference to the newly created entry
+                return *e_ptr;
+            }
+
+
+            /**
+             * Get an entry at row j and column i.
+             *
+             * @param j The row index
+             * @param i The column index
+             * @return a pointer to the entry, or a pointer to the corresponding column head.
+             * @throws std::std::invalid_argument if j or i are out of bounds.
+             */
+            ENTRY_OBJ &get_entry(int j, int i) {
+                if (j >= this->m || i >= this->n || j < 0 || i < 0)
+                    throw std::invalid_argument("Index i or j is out of bounds");
+
+                // Iterate over the column at index i and check each entry's row index.
+                // If the row index matches j, return that entry.
+                for (auto &e: this->reverse_iterate_column(i)) {
+                    if (e.row_index == j) return e;
+                }
+
+                // If no entry is found, return the column head at index i.
+                return *this->column_heads[i];
+            }
+
+
+            /**
+             * Insert a new row at row_index with entries at column indices col_indices.
+             *
+             * @param row_index The index of the row to insert.
+             * @param col_indices A vector of indices indicating which columns to insert entries into.
+             * @return a pointer to the row head entry for the newly inserted row.
+             */
+            ENTRY_OBJ *insert_row(int row_index, std::vector<int> &col_indices) {
+                // Insert an entry at each specified column index.
+                for (auto j: col_indices) {
+                    this->insert_entry(row_index, j);
+                }
+
+                // Return the row head at row_index.
+                return this->row_heads[row_index];
+            }
+
+
+            /**
+             * @brief Returns the coordinates of all non-zero entries in the matrix.
+             *
+             * @return Vector of vectors, where each inner vector represents the row and column indices of a non-zero entry.
+             */
+            std::vector<std::vector<int>> nonzero_coordinates() {
+
+                std::vector<std::vector<int>> nonzero;
+
+                // Initialize node count to 0
+                this->node_count = 0;
+
+                // Iterate through all rows and columns to find non-zero entries
+                for (int i = 0; i < this->m; i++) {
+                    for (auto &e: this->iterate_row(i)) {
+                        // Increment node count and add non-zero entry coordinates to vector
+                        this->node_count += 1;
+                        std::vector<int> coord;
+                        coord.push_back(e.row_index);
+                        coord.push_back(e.col_index);
+                        nonzero.push_back(coord);
+                    }
+                }
+
+                // Return vector of non-zero entry coordinates
+                return nonzero;
+
+            }
+            /**
+             * Returns row adjacency list as vector of vectors.
+             * @return
+             */
+            std::vector<std::vector<int>> row_adjacency_list() {
+                std::vector<std::vector<int>> adj_list;
+                for (int i = 0; i < this->m; i++) {
+                    std::vector<int> row;
+                    for (auto &e: this->iterate_row(i)) {
+                        row.push_back(e.col_index);
+                    }
+                    adj_list.push_back(row);
+                }
+                return adj_list;
+            }
+
+            std::vector<std::vector<int>> col_adjacency_list() {
+                std::vector<std::vector<int>> adj_list;
+                for (int i = 0; i < this->n; i++) {
+                    std::vector<int> col;
+                    for (auto &e: this->iterate_column(i)) {
+                        col.push_back(e.row_index);
+                    }
+                    adj_list.push_back(col);
+                }
+                return adj_list;
+            }
+
+            /**
+             * Return a single column as 1D csc_matrix
+             * @param col_index
+             * @return
+             */
+            std::vector<int> get_column_csc(const std::size_t col_index){
+                std::vector<int> col;
+                for (auto entry: this->iterate_column(col_index)) {
+                    col.push_back(entry.row_index);
+                }
+                return col;
+            }
+
+            CsrMatrix to_csr_matrix() {
+                CsrMatrix csr;
+                csr.m = this->m;
+                csr.n = this->n;
+                csr.entry_count = this->entry_count();
+                csr.row_adjacency_list = this->row_adjacency_list();
+                return csr;
+            }
+
+            /**
+            * Returns a vector of vectors, where each vector contains the column indices of the non-zero entries in a row.
+            * @return A vector of vectors, where each vector contains the column indices of the non-zero entries in a row.
+            */
+            std::vector<std::vector<int>> nonzero_rows() {
+
+                std::vector<std::vector<int>> nonzero;
+
+                this->node_count = 0; //reset node_count to 0
+
+                //iterate over the rows of the matrix
+                for (int i = 0; i < this->m; i++) {
+                    std::vector<int> row;
+
+                    //iterate over the entries in the current row
+                    for (auto &e: this->iterate_row(i)) {
+                        this->node_count += 1; //increment node_count
+                        row.push_back(
+                                e.col_index); //add the column index of the current entry to the current row vector
+                    }
+                    nonzero.push_back(row); //add the current row vector to the vector of non-zero rows
+                }
+
+                return nonzero;
+
+            }
+
+
+            /**
+             * @brief An iterator class that iterates over rows of a sparse matrix in a doubly linked list format.
+             *
+             * This class inherits from the Iterator class and is designed to work with SparseMatrixBase and its
+             * subclasses. It is used to iterate over the rows of a sparse matrix in a doubly linked list format.
+             *
+             * @tparam ENTRY_OBJ The entry object class that the sparse matrix will use for its entries. This class
+             * should contain fields for row index, column index, and value.
+             */
+            class RowIterator {
+            public:
+                using iterator_category = std::forward_iterator_tag;
+                using difference_type = std::ptrdiff_t;
+                SparseMatrixBase<ENTRY_OBJ> *matrix;
+                int it_count;
+                int entry_count;
+                ENTRY_OBJ *e;
+
+                RowIterator(SparseMatrixBase<ENTRY_OBJ> *mat, int i) {
+                    matrix = mat;
+                    entry_count = matrix->get_row_degree(i);
+                    it_count = 0;
+                    e = matrix->row_heads[i];
+                }
+
+                ~RowIterator() {};
+
+                RowIterator &end() {
+                    return *this;
+                }
+
+                RowIterator &begin() {
+                    e = e->right;
+                    ++it_count;
+                    return *this;
+                }
+
+                ENTRY_OBJ &operator*() {
+                    return *e;
+                }
+
+                // ENTRY_OBJ& operator*() {
+                //     return *e;
+                // }
+                friend bool operator==(const RowIterator &a, const RowIterator &b) {
+                    return a.it_count > b.entry_count;
+                };
+
+                friend bool operator!=(const RowIterator &a, const RowIterator &b) {
+                    return a.it_count <= b.entry_count;
+                };
+
+
+                RowIterator &operator++() {
+                    e = e->right;
+                    ++it_count;
+                    return *this;
+                }
+
+            };
+
+            /**
+             * @brief A reverse iterator for iterating over the rows of a SparseMatrixBase
+             *
+             * This iterator inherits from the `Iterator` base class using the CRTP pattern.
+             * It is designed to be used with a SparseMatrixBase object to iterate over the rows
+             * of the matrix in reverse order. It iterates over the rows in reverse order by
+             * starting at the `head->left` entry and moving to the left using the `operator++()`
+             * method. It can be indexed to start at any row of the matrix using the `operator[]`
+             * method.
+             *
+             * @tparam ENTRY_OBJ The entry object class that the iterator will use for its entries.
+             */
+            class ReverseRowIterator {
+            public:
+                using iterator_category = std::forward_iterator_tag;
+                using difference_type = std::ptrdiff_t;
+                SparseMatrixBase<ENTRY_OBJ> *matrix;
+                int it_count;
+                int entry_count;
+                ENTRY_OBJ *e;
+
+                ReverseRowIterator(SparseMatrixBase<ENTRY_OBJ> *mat, int i) {
+                    matrix = mat;
+                    entry_count = matrix->get_row_degree(i);
+                    it_count = 0;
+                    e = matrix->row_heads[i];
+                }
+
+                ~ReverseRowIterator() {};
+
+                ReverseRowIterator &end() {
+                    return *this;
+                }
+
+                ReverseRowIterator &begin() {
+                    e = e->left;
+                    ++it_count;
+                    return *this;
+                }
+
+                ENTRY_OBJ &operator*() {
+                    return *e;
+                }
+
+                friend bool operator==(const ReverseRowIterator &a, const ReverseRowIterator &b) {
+                    return a.it_count > b.entry_count;
+                };
+
+                friend bool operator!=(const ReverseRowIterator &a, const ReverseRowIterator &b) {
+                    return a.it_count <= b.entry_count;
+                };
+
+
+                ReverseRowIterator &operator++() {
+                    e = e->left;
+                    ++it_count;
+                    return *this;
+                }
+
+            };
+
+
+            /**
+             * @brief A forward iterator class that iterates over columns of a sparse matrix in a doubly linked list format.
+             *
+             * This class inherits from the Iterator class and is designed to work with SparseMatrixBase and its
+             * subclasses. It is used to iterate over the columns of a sparse matrix in a doubly linked list format.
+             *
+             * @tparam ENTRY_OBJ The entry object class that the sparse matrix will use for its entries. This class
+             * should contain fields for row index, column index, and value.
+             */
+            class ColumnIterator {
+            public:
+                using iterator_category = std::forward_iterator_tag;
+                using difference_type = std::ptrdiff_t;
+                SparseMatrixBase<ENTRY_OBJ> *matrix;
+                int it_count;
+                int entry_count;
+                ENTRY_OBJ *e;
+
+                ColumnIterator(SparseMatrixBase<ENTRY_OBJ> *mat, int i) {
+                    matrix = mat;
+                    entry_count = matrix->get_col_degree(i);
+                    it_count = 0;
+                    e = matrix->column_heads[i];
+                }
+
+                ~ColumnIterator() {};
+
+                ColumnIterator &end() {
+                    return *this;
+                }
+
+                ColumnIterator &begin() {
+                    e = e->down;
+                    ++it_count;
+                    return *this;
+                }
+
+                ENTRY_OBJ &operator*() {
+                    return *e;
+                }
+
+                friend bool operator==(const ColumnIterator &a, const ColumnIterator &b) {
+                    return a.it_count > b.entry_count;
+                };
+
+                friend bool operator!=(const ColumnIterator &a, const ColumnIterator &b) {
+                    return a.it_count <= b.entry_count;
+                };
+
+
+                ColumnIterator &operator++() {
+                    e = e->down;
+                    ++it_count;
+                    return *this;
+                }
+
+            };
+
+            /**
+             * @brief A reverse iterator class that iterates over rows of a sparse matrix in a doubly linked list format.
+             *
+             * This class inherits from the Iterator class and is designed to work with SparseMatrixBase and its
+             * subclasses. It is used to iterate over the rows of a sparse matrix in a doubly linked list format
+             * starting from the rightmost element in the row.
+             *
+             * @tparam ENTRY_OBJ The entry object class that the sparse matrix will use for its entries. This class
+             * should contain fields for row index, column index, and value.
+             */
+            class ReverseColumnIterator {
+            public:
+                using iterator_category = std::forward_iterator_tag;
+                using difference_type = std::ptrdiff_t;
+                SparseMatrixBase<ENTRY_OBJ> *matrix;
+                int it_count;
+                int entry_count;
+                ENTRY_OBJ *e;
+
+                ReverseColumnIterator(SparseMatrixBase<ENTRY_OBJ> *mat, int i) {
+                    matrix = mat;
+                    entry_count = matrix->get_col_degree(i);
+                    it_count = 0;
+                    e = matrix->column_heads[i];
+                }
+
+                ~ReverseColumnIterator() {};
+
+                ReverseColumnIterator &end() {
+                    return *this;
+                }
+
+                ReverseColumnIterator &begin() {
+                    e = e->up;
+                    ++it_count;
+                    return *this;
+                }
+
+                ENTRY_OBJ &operator*() {
+                    return *e;
+                }
+
+                friend bool operator==(const ReverseColumnIterator &a, const ReverseColumnIterator &b) {
+                    return a.it_count > b.entry_count;
+                };
+
+                friend bool operator!=(const ReverseColumnIterator &a, const ReverseColumnIterator &b) {
+                    return a.it_count <= b.entry_count;
+                };
+
+
+                ReverseColumnIterator &operator++() {
+                    e = e->up;
+                    ++it_count;
+                    return *this;
+                }
+
+            };
+
+
+            /**
+             * @brief Returns an iterator that iterates over the given row of the sparse matrix in a forward direction
+             *
+             * @param i The row index of the matrix to iterate over
+             * @throws std::invalid_argument If the given index is out of bounds
+             * @return RowIterator An iterator object that iterates over the given row
+             */
+            RowIterator iterate_row(int i) {
+                if (i < 0 || i >= m) throw std::invalid_argument("Iterator index out of bounds");
+                return RowIterator(this, i);
+            }
+
+            /**
+             * @brief Returns an iterator that iterates over the given row of the sparse matrix in a reverse direction
+             *
+             * @param i The row index of the matrix to iterate over
+             * @throws std::invalid_argument If the given index is out of bounds
+             * @return ReverseRowIterator An iterator object that iterates over the given row in reverse
+             */
+            ReverseRowIterator reverse_iterate_row(int i) {
+                if (i < 0 || i >= m) throw std::invalid_argument("Iterator index out of bounds");
+                return ReverseRowIterator(this, i);
+            }
+
+            /**
+             * @brief Returns an iterator that iterates over the given column of the sparse matrix in a forward direction
+             *
+             * @param i The column index of the matrix to iterate over
+             * @throws std::invalid_argument If the given index is out of bounds
+             * @return ColumnIterator An iterator object that iterates over the given column
+             */
+            ColumnIterator iterate_column(int i) {
+                if (i < 0 || i >= n) throw std::invalid_argument("Iterator index out of bounds");
+                return ColumnIterator(this, i);
+            }
+
+            /**
+             * @brief Returns an iterator that iterates over the given column of the sparse matrix in a reverse direction
+             *
+             * @param i The column index of the matrix to iterate over
+             * @throws std::invalid_argument If the given index is out of bounds
+             * @return ReverseColumnIterator An iterator object that iterates over the given column in reverse
+             */
+            ReverseColumnIterator reverse_iterate_column(int i) {
+                if (i < 0 || i >= n) throw std::invalid_argument("Iterator index out of bounds");
+                return ReverseColumnIterator(this, i);
+            }
+
+
+        };
+
+
+    }//end namespace
+} //end namespace
+
+
+#endif


### PR DESCRIPTION
Main purpose for the PR is to speedup the decoding process getting rid of the dependency of python module LDPC.

The decoding process depends on another decoder known as BP decoder, but we have not implemented such decoder and thus we used the python module LDPC to import this decoder and call it from C++. The context changes from C++/Python introduce timming overhead in the decoding process.

Thanks to the V2 implementation of the ![LDPC](https://github.com/quantumgizmos/ldpc_v2) module by ![quantumgizmos](https://github.com/quantumgizmos) we were ablo to use the BP version implemented in C++ and further speedup the BPOTF decoding method and also avoiding the dependency with LDPC module.