### PR TITLE
Support for Scipy.sparse.csc_matrix input type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ authors = [
 license = { file = "LICENSE" }
 
 requires-python = ">=3.8"
-dependencies = []
+dependencies = [
+   "scipy"
+]
 version = "0.0.1"
 
 [tool.setuptools.packages.find]

--- a/reference/algorithm2.py
+++ b/reference/algorithm2.py
@@ -23,6 +23,8 @@ import csv
 #from module import BPOTF #bpbp
 import BPOTF
 
+from scipy import sparse
+
 def error_generation(p, n):
     """Depolarizing error generation
 
@@ -205,8 +207,10 @@ if __name__ == "__main__":
             #     p
             # )
 
+            # pcm = pcm.astype(np.uint8)
+            pcm = sparse.csc_matrix(pcm, dtype=np.uint8)
             _bpotf = BPOTF.OBPOTF(
-                pcm.astype(np.uint8), 
+                pcm,
                 p
             )
             
@@ -214,7 +218,9 @@ if __name__ == "__main__":
             PlBPBP = 0
             PlBPOSD = 0
             time_av_BPOSD = 0
+            time_max_BPOSD = 0
             time_av_BPBP = 0
+            time_max_BPOTF = 0
             kruskal_time_list = []
             
             #print(pcm)
@@ -234,7 +240,10 @@ if __name__ == "__main__":
                 b = time.time()
                 time_av_BPOSD += (b-a)/NMCs[index]
                 times_BPOSD[distance].append(b-a)
+                time_max_BPOSD = max(time_max_BPOSD, (b-a))
+
                 recovered_error = _bp.decode(syndrome)
+
                 a = time.time()
                 #recovered_error_BPBP, kruskal_time = _uf.decode(syndrome)
                 # kruskal_time = 0.0
@@ -243,6 +252,7 @@ if __name__ == "__main__":
                 b = time.time()
                 time_av_BPBP += (b-a)/NMCs[index]
                 times_BPBP[distance].append(b-a)
+                time_max_BPOTF = max(time_max_BPOTF, (b-a))
                 
                 if np.any(pt.bsp(recovered_error_BPOSD ^ error, myCode.logicals.T) == 1):
                     PlBPOSD += 1/NMCs[index]
@@ -268,8 +278,8 @@ if __name__ == "__main__":
                 
             print(f'Physical error: {p}')
             print(f'Error BP: {PlBP}')
-            print(f'Error BPOSD: {PlBPOSD} with average time {time_av_BPOSD}')
-            print(f'Error BPBP: {PlBPBP} with average time {time_av_BPBP}')
+            print(f'Error BPOSD: {PlBPOSD} with average time {time_av_BPOSD} and max time {time_max_BPOSD}')
+            print(f'Error BPBP: {PlBPBP} with average time {time_av_BPBP} and max time {time_max_BPOTF}')
             
             # f.write(f'Distance: {distance} and physical error: {p}\n')
             # f.write('-------------------------------------------------\n')

--- a/src/BPOTF/OBPOTF.h
+++ b/src/BPOTF/OBPOTF.h
@@ -30,6 +30,9 @@
 
 namespace py = pybind11;
 
+#define C_FMT py::array::c_style
+#define F_FMT py::array::f_style
+
 class OBPOTF
 {
    private:
@@ -62,7 +65,11 @@ class OBPOTF
     *                avoid copying the matrix.
     * @param p[in]   Phisical error to initialize the bp_decoder.
     *******************************************************************************************************************/
-   OBPOTF(py::array_t<uint8_t, py::array::f_style> const & pcm, float const & p);
+   OBPOTF(py::object const & pcm, float const & p);
+
+   void OBPOTF_init_from_numpy(py::array_t<uint8_t, F_FMT> const & pcm);
+   
+   void OBPOTF_init_from_scipy_csc(py::object const & pcm);
 
    /********************************************************************************************************************
     * @brief Delete default constructor, to avoid empty objects.
@@ -74,7 +81,7 @@ class OBPOTF
     *******************************************************************************************************************/
    ~OBPOTF();
 
-   py::array_t<uint8_t> decode(py::array_t<uint8_t, py::array::c_style> syndrome);
+   py::array_t<uint8_t> decode(py::array_t<uint8_t, C_FMT> syndrome);
 
    /********************************************************************************************************************
     * @brief Prints the object's member. Developing purposes and testing.

--- a/src/py11_iface.cpp
+++ b/src/py11_iface.cpp
@@ -10,7 +10,7 @@ namespace py = pybind11;
 // Bindings for the bpbp module
 PYBIND11_MODULE(BPOTF, BPOTF) {
    py::class_<OBPOTF>(BPOTF,"OBPOTF")
-      .def(py::init<py::array_t<uint8_t, py::array::f_style> const &, float const &>())
+      .def(py::init<py::object const &, float const &>())
       .def("print_object", &OBPOTF::print_object)
       .def("decode", &OBPOTF::decode);
 }


### PR DESCRIPTION
As the title states, add support to accept as constructor input the object scipy.sparse.csc_matrix as uint8 type.

Dependency on scipy module.